### PR TITLE
Upgrade to serialport 7.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# this is a fork that upgrades the serialport version
+
 # mindwave
 A cross-platform driver for bluetooth Neurosky Mindwave headsets.
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "buffy": "0.0.5",
-    "serialport": "^4.0.1"
+    "serialport": "^7.0.2"
   },
   "description": "A cross-platform driver for bluetooth Neurosky Mindwave headsets",
   "keywords": [


### PR DESCRIPTION
Current version of serialport fails to compile with node 10. Upgraded to 7.0.2 per this thread: https://github.com/p5-serial/p5.serialport/issues/49#issuecomment-439649588