### PR TITLE
Fix how the raw wave data value is parsed.

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,7 +92,11 @@ Mindwave.prototype.parsePacket = function(data) {
 
       case CODE_WAVE:
         var b = reader.buffer(3);
-        this.emit('wave', (b[1] << 8) | b[2]);
+        var raw = b[1]*256 + b[2];
+        if(raw >= 32768) {
+          raw = raw - 65536;
+        }
+        this.emit('wave', raw);
         break;
 
       case CODE_ASIC_EEG:

--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ Mindwave.prototype.parsePacket = function(data) {
 
       case CODE_WAVE:
         var b = reader.buffer(3);
-        var raw = b[1]*256 + b[2];
+        var raw = b[1] * 256 + b[2];
         if(raw >= 32768) {
           raw = raw - 65536;
         }

--- a/index.js
+++ b/index.js
@@ -91,6 +91,8 @@ Mindwave.prototype.parsePacket = function(data) {
         break;
 
       case CODE_WAVE:
+        // Calculation method taken from:
+        // http://developer.neurosky.com/docs/doku.php?id=thinkgear_communications_protocol#raw_wave_value_16-bit
         var b = reader.buffer(3);
         var raw = b[1] * 256 + b[2];
         if(raw >= 32768) {

--- a/index.js
+++ b/index.js
@@ -91,7 +91,8 @@ Mindwave.prototype.parsePacket = function(data) {
         break;
 
       case CODE_WAVE:
-        this.emit('wave', reader.int16BE());
+        var b = reader.buffer(3);
+        this.emit('wave', (b[1] << 8) | b[2]);
         break;
 
       case CODE_ASIC_EEG:


### PR DESCRIPTION
Currently the raw wave date value is calculated using the first two bytes in the buffer but this results in incorrect data. This patch changes it to use the second two bytes instead which give the correct result.